### PR TITLE
Support multiple accounts (preserve "authuser" query parameter).

### DIFF
--- a/background.js
+++ b/background.js
@@ -84,12 +84,12 @@ chrome.tabs.onUpdated.addListener((tabId, tabChangeInfo, tab) => {
 
         // only attempt a redirect when not the PWA
         if (tab.windowId !== googleMeetWindowId) {
-          const queryParameters = tab.url.split('/')[3].split('?')[0];
-          if (queryParameters !== 'new' && queryParameters !== '_meet') {
-            // if empty, set the the landing page
+          const parameters = tab.url.split('/')[3];
+          if (!parameters.startsWith('new') && !parameters.startsWith('_meet')) {
+            // if empty, set the landing page
             chrome.storage.local.set({
               originatingTabId: tabId,
-              queryParams: queryParameters,
+              queryParams: parameters,
             });
           }
         }

--- a/contentScript.js
+++ b/contentScript.js
@@ -26,8 +26,10 @@
 
         const qp = changes['queryParams'].newValue;
         const newQueryParams = qp.includes('?')
-          ? qp + '&authuser=0'
-          : qp + '?authuser=0';
+        ? qp.includes('authuser=')
+          ? qp 
+          : qp + '&authuser=0'
+        : qp + '?authuser=0';
 
         const currentHref = window.location.href;
         const newHref = 'https://meet.google.com/' + newQueryParams;


### PR DESCRIPTION
I use Notion calendar that allows to connect multiple Google calendars.
Meetings there have "Join Google Meet meetings" button that opens a standard link to a Google Meet meeting containing `authuser` parameter set to an email of an account owning this meeting.
I made a few changes that preserve `authuser` parameter while redirecting.